### PR TITLE
Fix issues with loading and saving benchmark's config files

### DIFF
--- a/dacbench/abstract_benchmark.py
+++ b/dacbench/abstract_benchmark.py
@@ -86,6 +86,8 @@ class AbstractBenchmark:
                             and -np.inf not in conf[k][i]
                         ):
                             conf[k][i] = list(map(int, conf[k][i]))
+                elif isinstance(conf[k],np.ndarray):                    
+                    conf[k] = conf[k].tolist()
 
         conf["wrappers"] = self.jsonify_wrappers()
 

--- a/dacbench/abstract_benchmark.py
+++ b/dacbench/abstract_benchmark.py
@@ -201,9 +201,12 @@ class AbstractBenchmark:
         if "observation_space_type" in self.config:
             # Types have to be numpy dtype (for gym spaces)s
             if type(self.config["observation_space_type"]) == str:
-                typestring = self.config["observation_space_type"].split(" ")[1][:-2]
-                typestring = typestring.split(".")[1]
-                self.config["observation_space_type"] = getattr(np, typestring)
+                if self.config["observation_space_type"] == "None":
+                    self.config["observation_space_type"] = None
+                else:
+                    typestring = self.config["observation_space_type"].split(" ")[1][:-2]
+                    typestring = typestring.split(".")[1]
+                    self.config["observation_space_type"] = getattr(np, typestring)
         if "observation_space" in self.config:
             self.config["observation_space"] = self.list_to_space(
                 self.config["observation_space"]


### PR DESCRIPTION
Hello,

There are two issues I encountered when loading and saving `.json` config files;

- Issue 1: `AbstractBenchmark.read_config_file` doesn't handle the case when `observation_space_type` is `None`. To reproduce the issue:
```
bench = CMAESBenchmark()
bench.save_config("test-config.json")
bench.read_config_file("test-config.json")
```

- Issue 2: `AbstractBenchmark.save_config` doesn't handle 1d numpy array. To reproduce the issue:
```
bench = LubyBenchmark("dacbench/additional_configs/luby/luby_hard.json")
bench.save_config("test-config.json")
```

This pull request is to fix those issues. Could you please have a look?

Thanks!
Nguyen