### PR TITLE
use numpy functions to prevent single element array in the observation

### DIFF
--- a/dacbench/envs/modea.py
+++ b/dacbench/envs/modea.py
@@ -234,13 +234,13 @@ class ModeaEnv(AbstractEnv):
         self.es.parameters.weights = self.es.parameters.getWeights(
             self.es.parameters.weights_option
         )
-        self.es.parameters.mu_eff = 1 / sum(np.square(self.es.parameters.weights))
+        self.es.parameters.mu_eff = 1 / np.sum(np.square(self.es.parameters.weights))
         mu_eff = self.es.parameters.mu_eff  # Local copy
         n = self.es.parameters.n
         self.es.parameters.c_sigma = (mu_eff + 2) / (mu_eff + n + 5)
         self.es.parameters.c_c = (4 + mu_eff / n) / (n + 4 + 2 * mu_eff / n)
         self.es.parameters.c_1 = 2 / ((n + 1.3) ** 2 + mu_eff)
-        self.es.parameters.c_mu = min(
+        self.es.parameters.c_mu = np.min(
             1 - self.es.parameters.c_1,
             self.es.parameters.alpha_mu
             * (


### PR DESCRIPTION
Using `sum` instead of `np.sum` creates single element np arrays which causes
`TypeError: can't convert np.ndarray of type numpy.object_. The only supported types are: float64, float32, float16, complex64, complex128, int64, int32, int16, int8, uint8, and bool.` when used with `torch.from_numpy`  to pass the observation to a torch model.

Example:
I put print statements in `get_default_state` and then run an agent in the environment. After 2 steps it crashed with the above error.
```
Type of Sigma: <class 'int'>
C Sigma: 0.28442858794636744
Sigma: 1
MU: 3.1672992814107017
Observation: [  0   1 100  11   0]

Type of Sigma: <class 'numpy.ndarray'>
C Sigma: [0.28442859]
Sigma: [11.63864193]
MU: [3.16729928]
Observation: [10 array([11.63864193]) 90 11 0]
```


Using `np.sum` fixes this problem. 