### PR TITLE
test(sgd): speed up and harden SGD env/benchmark tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,9 @@ convention = "google"
 max-args = 10 # Changed from default of 5
 
 [tool.pytest.ini_options]
+markers = [
+    "slow: marks tests that require network access or heavy computation (deselect with -m 'not slow')",
+]
 filterwarnings = [
     "ignore::UserWarning",
     "ignore::DeprecationWarning",

--- a/tests/benchmarks/test_sgd_benchmark.py
+++ b/tests/benchmarks/test_sgd_benchmark.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import json
 import os
 import unittest
+from unittest.mock import patch
+
 import numpy as np
 
+from tests.helpers import tiny_sgd_loader
 from dacbench.benchmarks import SGDBenchmark
 from dacbench.envs import SGDEnv, SGDInstance
 
@@ -78,24 +81,39 @@ class TestSGDBenchmark(unittest.TestCase):
     def test_seeding(self):
         bench = SGDBenchmark()
         bench.config.seed = 123
+        bench.config.seed_action_space = True
+        bench.config.instance_update_func = "no_progression"
         mems = []
-        instances = []
 
-        for _ in range(2):
-            env = bench.get_environment()
-            env.instance_index = 0
-            instances.append(env.get_instance_set())
+        with patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
+            for _ in range(2):
+                env = bench.get_environment()
+                assert env.instance is env.instance_set[0]
 
-            state, _ = env.reset()
+                state, _ = env.reset()
 
-            terminated, truncated = False, False
-            mem = []
-            step = 0
-            while not (terminated or truncated) and step < 5:
-                action = env.action_space.sample()
-                state, reward, terminated, truncated, _ = env.step(action)
-                mem.append([state, [reward, int(truncated), action]])
-                step += 1
-            mems.append(mem)
+                terminated, truncated = False, False
+                mem = []
+                step = 0
+                while not (terminated or truncated) and step < 5:
+                    action = env.action_space.sample()
+                    state, reward, terminated, truncated, _ = env.step(action)
+                    mem.append([state, [reward, int(truncated), action]])
+                    step += 1
+                mems.append(mem)
+
+        # Trajectories must be reproducible under the same seed.
         assert len(mems[0]) == len(mems[1])
-        assert instances[0] == instances[1]
+        for mem0, mem1 in zip(mems[0], mems[1], strict=True):
+            state0, (reward0, trunc0, action0) = mem0
+            state1, (reward1, trunc1, action1) = mem1
+            assert trunc0 == trunc1
+            assert np.allclose(reward0, reward1), f"reward differs: {reward0} vs {reward1}"
+            assert np.allclose(action0, action1), f"action differs: {action0} vs {action1}"
+            assert state0.keys() == state1.keys()
+            for k in state0:
+                v0, v1 = state0[k], state1[k]
+                if isinstance(v0, (bool, int)):
+                    assert v0 == v1, f"state[{k}] differs: {v0!r} vs {v1!r}"
+                else:
+                    assert np.allclose(v0, v1), f"state[{k}] differs: {v0!r} vs {v1!r}"

--- a/tests/envs/test_deterministic.py
+++ b/tests/envs/test_deterministic.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 from dacbench import benchmarks
 from numpy.testing import assert_almost_equal
+
+from tests.helpers import tiny_sgd_loader
 
 
 def assert_state_space_equal(state1, state2):
@@ -22,16 +25,20 @@ def assert_state_space_equal(state1, state2):
 
 
 class TestDeterministic(unittest.TestCase):
-    def run_deterministic_test(self, benchmark_name, seed=42):
+    def run_deterministic_test(self, benchmark_name, seed=42, instance_update_func=None):
         print(benchmark_name)
         bench = getattr(benchmarks, benchmark_name)()
         action = bench.get_environment().action_space.sample()
 
         env1 = bench.get_benchmark(seed=seed)
+        if instance_update_func is not None:
+            env1.instance_updates = instance_update_func
         init_state1, info1 = env1.reset()
         _, reward1, terminated1, truncated1, info1 = env1.step(action)
 
         env2 = bench.get_benchmark(seed=seed)
+        if instance_update_func is not None:
+            env2.instance_updates = instance_update_func
         init_state2, info2 = env2.reset()
         _, reward2, terminated2, truncated2, info2 = env2.step(action)
 
@@ -74,7 +81,8 @@ class TestDeterministic(unittest.TestCase):
     #     self.assertEqual(info1, info2)
 
     def test_SGDBenchmark(self):
-        self.run_deterministic_test("SGDBenchmark")
+        with patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
+            self.run_deterministic_test("SGDBenchmark", instance_update_func="no_progression")
 
     def test_OneLLBenchmark(self):
         ...

--- a/tests/envs/test_sgd.py
+++ b/tests/envs/test_sgd.py
@@ -14,11 +14,14 @@ from dacbench.envs.env_utils import sgd_utils
 from dacbench.envs.sgd import SGDEnv, SGDInstance
 from dacbench.wrappers import ObservationWrapper
 
+from tests.helpers import tiny_sgd_loader
+
 
 class TestSGDEnv(unittest.TestCase):
     def make_env(self, epoch=True):
         bench = SGDBenchmark()
         bench.config.epoch_mode = epoch
+        bench.config.instance_update_func = "no_progression"
         return bench.get_environment()
 
     @staticmethod
@@ -88,27 +91,31 @@ class TestSGDEnv(unittest.TestCase):
             assert env.min_validation_loss is not None
 
     def test_multiple_epochs(self):
-        env = self.make_env()
-        _ = env.reset()
-        action = env.action_space.sample()
-        for _ in range(5):
-            _, reward, _, _, _ = env.step(action)
-            assert reward > env.crash_penalty, "Env should not crash"
+        with patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
+            env = self.make_env()
+            _ = env.reset()
+            action = env.action_space.sample()
+            for _ in range(5):
+                _, reward, _, _, _ = env.step(action)
+                assert reward > env.crash_penalty, "Env should not crash"
 
+    @pytest.mark.slow
     def test_torch_hub_loading(self):
         bench = SGDBenchmark()
         env = bench.get_environment()
         env.instance_id_list = [0]
         env.instance_set = {0: env.instance_set[0]}
         env.instance_set[0].model = sgd_utils.load_model_from_torchhub(model_repo="chenyaofo/pytorch-cifar-models", model_name="cifar10_resnet20", pretrained=False)
-        env.reset()
-        assert env.model is not None
-        assert env.model.__class__.__name__ == "Sequential"
-        print(env.instance.dataset_name)
-        env.step(0.001)
+        with patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
+            env.reset()
+            assert env.model is not None
+            assert env.model.__class__.__name__ == "Sequential"
+            print(env.instance.dataset_name)
+            env.step(0.001)
 
     def test_crash(self):
-        with patch("dacbench.envs.sgd.forward_backward") as mock_forward_backward:
+        with patch("dacbench.envs.sgd.forward_backward") as mock_forward_backward, \
+             patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
             mock_forward_backward.return_value = torch.tensor(float("inf"))
             env = ObservationWrapper(self.make_env())
             state, info = env.reset()
@@ -121,28 +128,44 @@ class TestSGDEnv(unittest.TestCase):
 
     def test_reproducibility(self):
         mems = []
-        instances = []
-        env = self.make_env()
+        bench = SGDBenchmark()
+        bench.config.instance_update_func = "no_progression"
 
-        for _ in range(2):
-            rng = np.random.default_rng(123)
-            env.seed(123)
-            env.instance_index = 0
-            instances.append(env.get_instance_set())
+        with patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
+            for _ in range(2):
+                env = bench.get_environment()
+                rng = np.random.default_rng(123)
+                env.seed(123)
+                # Sanity check: env remains anchored to instance 0 across resets.
+                assert env.instance is env.instance_set[0]
 
-            state, info = env.reset()
+                state, info = env.reset()
 
-            terminated, truncated = False, False
-            mem = []
-            step = 0
-            while not (terminated or truncated) and step < 5:
-                action = np.exp(rng.integers(low=-10, high=1))
-                state, reward, terminated, truncated, _ = env.step(action)
-                mem.append([state, [reward, int(truncated), action]])
-                step += 1
-            mems.append(mem)
+                terminated, truncated = False, False
+                mem = []
+                step = 0
+                while not (terminated or truncated) and step < 5:
+                    action = np.exp(rng.integers(low=-10, high=1))
+                    state, reward, terminated, truncated, _ = env.step(action)
+                    mem.append([state, [reward, int(truncated), action]])
+                    step += 1
+                mems.append(mem)
+
+        # Trajectories must be reproducible under the same seed.
         assert len(mems[0]) == len(mems[1])
-        assert instances[0] == instances[1]
+        for mem0, mem1 in zip(mems[0], mems[1], strict=True):
+            state0, (reward0, trunc0, action0) = mem0
+            state1, (reward1, trunc1, action1) = mem1
+            assert trunc0 == trunc1
+            assert np.allclose(reward0, reward1), f"reward differs: {reward0} vs {reward1}"
+            assert np.allclose(action0, action1), f"action differs: {action0} vs {action1}"
+            assert state0.keys() == state1.keys()
+            for k in state0:
+                v0, v1 = state0[k], state1[k]
+                if isinstance(v0, (bool, int)):
+                    assert v0 == v1, f"state[{k}] differs: {v0!r} vs {v1!r}"
+                else:
+                    assert np.allclose(v0, v1), f"state[{k}] differs: {v0!r} vs {v1!r}"
 
     def test_invalid_model(self):
         bench = SGDBenchmark()
@@ -185,8 +208,9 @@ class TestSGDEnv(unittest.TestCase):
         assert env.close() is None
 
     def test_render(self):
-        env = self.make_env()
-        state, info = env.reset()
-        env.render("human")
-        with pytest.raises(NotImplementedError):
-            env.render("random")
+        with patch("dacbench.envs.sgd.random_torchvision_loader", side_effect=tiny_sgd_loader):
+            env = self.make_env()
+            state, info = env.reset()
+            env.render("human")
+            with pytest.raises(NotImplementedError):
+                env.render("random")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def tiny_sgd_loader(*args, **kwargs):
+    """Tiny seeded in-memory dataset replacing CIFAR-10 for fast SGD tests.
+
+    Uses a local Generator so the global PyTorch RNG is not affected.
+    """
+    rng = torch.Generator().manual_seed(0)
+    x = torch.rand(256, 3, 32, 32, generator=rng)
+    y = torch.randint(0, 10, (256,), generator=rng)
+    train_ds = TensorDataset(x[:192], y[:192])
+    val_ds = TensorDataset(x[192:], y[192:])
+    test_ds = TensorDataset(x[:64], y[:64])
+    train_loader = DataLoader(train_ds, batch_size=32, shuffle=True, drop_last=True, generator=torch.Generator().manual_seed(0))
+    val_loader = DataLoader(val_ds, batch_size=32, shuffle=True, generator=torch.Generator().manual_seed(0))
+    test_loader = DataLoader(test_ds, batch_size=32)
+    return (train_ds, test_ds), (train_loader, val_loader, test_loader)


### PR DESCRIPTION
- Add tests/helpers.py with tiny_sgd_loader: replaces CIFAR-10 with a tiny seeded in-memory TensorDataset (192 train / 64 val / 64 test, batch_size=32, local Generator for shuffle). Eliminates disk I/O and cuts training batches from 38+ per epoch to 6.

- Patch random_torchvision_loader in all slow SGD tests: test_seeding, test_crash, test_multiple_epochs, test_render, test_reproducibility (test_sgd_benchmark.py + test_sgd.py)

- Apply same patch to TestDeterministic::test_SGDBenchmark via run_deterministic_test(..., instance_update_func='no_progression')

- Mark test_torch_hub_loading as @pytest.mark.slow (unavoidable network download); register 'slow' marker in pyproject.toml

- Fix test_reproducibility: move get_environment() inside the loop so SGDEnv.__init__ resets torch.manual_seed each iteration, restoring the determinism that was implicit in the original make_env() pattern