### PR TITLE
docs: mock smac and omegaconf for autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,4 +50,6 @@ options = {
         "sphinx.ext.doctest",
     ],
 }
+autodoc_mock_imports = ["smac", "omegaconf"]
+
 automl_sphinx_theme.set_options(globals(), options)


### PR DESCRIPTION
Allows the DACBO benchmark page to build without the dacboenv optional dependencies installed.