### PR TITLE
fix(function_approximation): align action_space with discrete bins an…

### DIFF
--- a/dacbench/benchmarks/function_approximation_benchmark.py
+++ b/dacbench/benchmarks/function_approximation_benchmark.py
@@ -68,6 +68,17 @@ class FunctionApproximationBenchmark(AbstractBenchmark):
     relevant functions for Function Approximation.
     """
 
+    @staticmethod
+    def _isolate_benchmark_info(config):
+        """Deep-copy `benchmark_info` (and its state_description list) so
+        that per-instance mutations do not leak into the module-level INFO
+        dict. Idempotent: safe to call multiple times on the same config.
+        """
+        config["benchmark_info"] = objdict(config["benchmark_info"])
+        config["benchmark_info"]["state_description"] = list(
+            config["benchmark_info"]["state_description"]
+        )
+
     def __init__(self, config_path=None, config=None):
         """Initialize Function Approximation Benchmark.
 
@@ -81,15 +92,29 @@ class FunctionApproximationBenchmark(AbstractBenchmark):
             self.config = objdict(FUNCTION_APPROXIMATION_DEFAULTS.copy())
 
         for key in FUNCTION_APPROXIMATION_DEFAULTS:
-            if key not in self.config:
-                if key == "observation_space_args" and "config_space" in self.config:
-                    obs_length = 1 + len(self.config["config_space"]) * 4
-                    self.config[key] = [
-                        np.array([-np.inf for _ in range(obs_length)]),
-                        np.array([np.inf for _ in range(obs_length)]),
-                    ]
-                else:
-                    self.config[key] = FUNCTION_APPROXIMATION_DEFAULTS[key]
+            if key not in self.config and key != "observation_space_args":
+                self.config[key] = FUNCTION_APPROXIMATION_DEFAULTS[key]
+
+        self._isolate_benchmark_info(self.config)
+
+        if "observation_space_args" not in self.config:
+            if "config_space" in self.config:
+                # Derive obs length from `state_description` so it stays
+                # consistent regardless of `omit_instance_type` or the
+                # length of `instance_description` returned by the toy
+                # functions. The state produced by FunctionApproximationEnv
+                # has exactly one entry per item in `state_description`.
+                # Deferred until after the default-fill loop so that
+                # `benchmark_info.state_description` is guaranteed to be set.
+                obs_length = len(self.config["benchmark_info"]["state_description"])
+                self.config["observation_space_args"] = [
+                    np.array([-np.inf for _ in range(obs_length)]),
+                    np.array([np.inf for _ in range(obs_length)]),
+                ]
+            else:
+                self.config["observation_space_args"] = FUNCTION_APPROXIMATION_DEFAULTS[
+                    "observation_space_args"
+                ]
 
     def get_environment(self):
         """Return Function Approximation env with current configuration.
@@ -187,6 +212,7 @@ class FunctionApproximationBenchmark(AbstractBenchmark):
             Sigmoid environment
         """
         self.config = objdict(FUNCTION_APPROXIMATION_DEFAULTS.copy())
+        self._isolate_benchmark_info(self.config)
         self.config.omit_instance_type = True
         if dimension == 1:
             self.config.instance_set_path = "sigmoid_1D3M_train.csv"
@@ -194,7 +220,7 @@ class FunctionApproximationBenchmark(AbstractBenchmark):
             self.config.discrete = [3]
             cfg_space = CS.ConfigurationSpace()
             dim1 = CSH.UniformIntegerHyperparameter(
-                name="value_dim_1", lower=0, upper=3
+                name="value_dim_1", lower=0, upper=2
             )
             cfg_space.add(dim1)
             self.config.config_space = cfg_space

--- a/tests/benchmarks/test_function_approximation_benchmark.py
+++ b/tests/benchmarks/test_function_approximation_benchmark.py
@@ -4,7 +4,13 @@ import json
 import os
 import unittest
 
+import gymnasium as gym
+from dacbench.abstract_benchmark import objdict
 from dacbench.benchmarks import FunctionApproximationBenchmark
+from dacbench.benchmarks.function_approximation_benchmark import (
+    FUNCTION_APPROXIMATION_DEFAULTS,
+    INFO,
+)
 from dacbench.envs import FunctionApproximationEnv, FunctionApproximationInstance
 
 
@@ -42,3 +48,96 @@ class TestFunctionApproximationBenchmark(unittest.TestCase):
         assert env.instance_set[0].functions[0].a == first_inst.functions[0].a    
         assert env.instance_set[0].functions[0].b == first_inst.functions[0].b    
         assert len(env.instance_set.keys()) == 300
+
+    def test_action_space_matches_discrete_bins(self):
+        """Regression: action_space size must equal the per-dim bin count
+        declared in `config.discrete` for every `get_benchmark(dimension=...)`.
+        """
+        bench = FunctionApproximationBenchmark()
+        for dim in (1, 2, 3, 5):
+            with self.subTest(dimension=dim):
+                env = bench.get_benchmark(dimension=dim, seed=0)
+                env.reset(seed=0)
+                discrete = env.config.discrete
+                action_space = env.action_space
+
+                # The action space shape must mirror the bin count per dim.
+                if isinstance(action_space, gym.spaces.Discrete):
+                    # dimension == 1: a single Integer HP collapses to Discrete(n)
+                    assert action_space.n == discrete[0]
+                elif isinstance(action_space, gym.spaces.MultiDiscrete):
+                    assert tuple(action_space.nvec) == tuple(discrete)
+                else:  # Dict fallback for mixed-type config_spaces
+                    names = list(action_space.spaces.keys())
+                    assert len(names) == len(discrete)
+                    for name, n_bins in zip(names, discrete, strict=True):
+                        assert action_space.spaces[name].n == n_bins
+
+                # Stepping with the largest valid index per dim must not raise
+                # and must produce a state that fits the observation space.
+                max_action = {
+                    f"value_dim_{i + 1}": int(n_bins) - 1
+                    for i, n_bins in enumerate(discrete)
+                }
+                state, _reward, _term, _trunc, _info = env.step(max_action)
+                assert state.shape == env.observation_space.shape
+
+    def test_observation_space_matches_state_description(self):
+        """Regression: when observation_space_args is auto-derived from
+        config_space, its length must match the actual state shape.
+
+        Previously the formula `1 + len(config_space) * 4` hardcoded the
+        assumption that every function exposes 3 instance_description entries
+        and `omit_instance_type=False`. With `omit_instance_type=True` the
+        identifier is dropped, so state shape is `1 + N*2 + N = 1 + 3N` while
+        the old formula gives `1 + 4N`. The two diverge for any N>0 — this
+        test uses the default config_space (N=2) and a state_description
+        sized for `omit_instance_type=True` so the new formula
+        (`len(state_description)`) gives the correct 7-element obs.
+        """
+        # 1 budget + 2 dims * 2 instance params + 2 actions = 7
+        benchmark_info = objdict(FUNCTION_APPROXIMATION_DEFAULTS.benchmark_info)
+        benchmark_info["state_description"] = [
+            "Remaining Budget",
+            "Function Parameter 1 (dimension 1)",
+            "Function Parameter 2 (dimension 1)",
+            "Function Parameter 1 (dimension 2)",
+            "Function Parameter 2 (dimension 2)",
+            "Action 1",
+            "Action 2",
+        ]
+        bench = FunctionApproximationBenchmark(
+            config=objdict(
+                {
+                    "config_space": FUNCTION_APPROXIMATION_DEFAULTS.config_space,
+                    "omit_instance_type": True,
+                    "benchmark_info": benchmark_info,
+                }
+            )
+        )
+        env = bench.get_environment()
+
+        state, _info = env.reset(seed=0)
+        assert state.shape == env.observation_space.shape
+        assert env.observation_space.shape[0] == len(
+            env.config.benchmark_info["state_description"]
+        )
+
+    def test_info_not_mutated_by_get_benchmark(self):
+        """Regression: get_benchmark must not mutate the module-level INFO
+        dict via shallow-copied benchmark_info. Previously, every call to
+        `get_benchmark(dimension=...)` reassigned `self.config` to a shallow
+        copy of FUNCTION_APPROXIMATION_DEFAULTS and then mutated
+        `benchmark_info["state_description"]` — leaking into INFO and
+        polluting subsequent benchmark constructions.
+        """
+        original = list(INFO["state_description"])
+        try:
+            bench = FunctionApproximationBenchmark()
+            for dim in (1, 2, 3, 5):
+                bench.get_benchmark(dimension=dim, seed=0)
+            assert INFO["state_description"] == original
+        finally:
+            # Defensive: restore INFO in case the test fails mid-loop and
+            # leaves the module state polluted for subsequent tests.
+            INFO["state_description"] = original


### PR DESCRIPTION
…d isolate benchmark_info

Three related bugs in FunctionApproximationBenchmark:

1. Action space mismatch (dimension=1) get_benchmark(dimension=1) set discrete=[3] (3 bins, valid indices 0..2) but the Integer hyperparameter used upper=3, producing Discrete(4). Stepping with action index 3 raised IndexError inside env.step() because np.linspace(0, 1, 3) only has indices 0..2. Fixed by setting upper=2 to match discrete=[3] and the other dimensions (2/3/5).

2. observation_space_args derivation hardcoded 3-entry instance_descriptions The formula '1 + len(config_space) * 4' assumed omit_instance_type=False and a fixed 3-entry instance_description per function. Replaced with len(state_description) so it stays consistent regardless of omit_instance_type or the toy function's instance_description shape.

3. Module-level INFO dict leaked across benchmark constructions get_benchmark() reassigned self.config to a shallow copy of FUNCTION_APPROXIMATION_DEFAULTS and then mutated benchmark_info['state_description'] per dimension. Because the copy was shallow, this overwrote the shared INFO dict and polluted subsequent benchmark constructions / tests. Added _isolate_benchmark_info() helper that deep-copies benchmark_info and its state_description list, called in both __init__ and get_benchmark.

Added regression tests:
- test_action_space_matches_discrete_bins: verifies Discrete.n / MultiDiscrete.nvec matches config.discrete for dimensions 1, 2, 3, 5 and that stepping with the max valid index returns a state of shape observation_space.shape.
- test_observation_space_matches_state_description: triggers the auto-derivation path with omit_instance_type=True and a state_description sized accordingly; verifies observation_space.shape == state.shape.
- test_info_not_mutated_by_get_benchmark: snapshots INFO, runs get_benchmark for all dimensions, asserts INFO is unchanged.